### PR TITLE
Introduce tests and clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+include bml
+
+BATS   = $(call required-command,bats)
+
+TEST_DIR := test/
+
+.PHONY: check
+
+check: ; ${BATS} -r ${TEST_DIR}

--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+* Prefer using trailing - in existence tests
+* Add (Dockerized) check task
+

--- a/build.properties
+++ b/build.properties
@@ -1,1 +1,0 @@
-VERSION=ls

--- a/release
+++ b/release
@@ -5,32 +5,32 @@ set -e
 # @file release
 # Perform a release for the current project.
 #
-# A release primarily consists creating a git tag for the released version
-# and tracking the resulting versions in a build properties file passed as an argument.
+# A release primarily consists of creating a git tag for the version
+# and recording the version in a properties file passed as an argument.
 #
 # @author Brightcove
 # @copyright Apache License, Version 2.0
 # @version 1.1.0
 # source_repository https://github.com/brightcove/buildsrc
 #
-# @param $1 The path to the properties file where the version is stored. .
+# @param $1 The path to the properties file where the version is stored.
 ##
 
-#-------------------------------------------------------------------------------
-# Copyright 2018 Brightcove
+#-------------------------------------------------------------------------
+# Copyright 2019 Brightcove
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#-------------------------------------------------------------------------------
+#-------------------------------------------------------------------------
 
 ##
 # This script depends on several environment variables being provided.
@@ -39,10 +39,22 @@ set -e
 ##
 
 ##
+# Alias for the name used to invoke this script.
+##
+declare -r me=$0
+
+##
 # The properties file which contains the version to release.
 #
 # This file should contain a line similar to:
 # VERSION=1.0.0-SNAPSHOT
+#
+# This script is designed to work with multi-part version
+# numbers such as the triplets used in semantic versioning.
+# Behavior with other styles of version numbers is currently
+# unspecified and not likely to be desirable.
+# There is upcoming work to allow customization of version
+# number management.
 ##
 declare -r prop_file=$1
 
@@ -54,58 +66,211 @@ declare -r prop_file=$1
 declare VERSION
 
 ##
+# If true then the default versions will be used without prompting.
+##
+declare -r AUTO_VERSION
+
+##
+# If specified then use this as the version to release.
+#
+# This will ignore the value currently in build.properties.
+##
+declare -r RELEASE_VERSION
+
+##
 # The git executable to call. If not already set will look on the path.
 ##
 declare GIT
 
 ##
-# (Optional) Where hook scripts are located. Defaults to directory of release script.
+# (Optional) Where hook scripts are located.
 #
-# Hook scripts allow for plugging in additional functionality to the release flow.
+# Defaults to directory of release script.
+#
+# Hook scripts allow for plugging in functionality to the release flow.
 # Currently supported hook is:
 #   - release::pre_release_hook
 ##
 declare RELEASE_HOOK_DIR
 
 ##
+# (Optional) Whether to output additional information.
+#
+# If passed, then this script will be chatty,
+# otherwise silence implies success.
+##
+declare -r RELEASE_VERBOSE
+
+##
 # (Optional) Whether this is a release from a branch.
 #
-# Branch releases may be less restrictive but also mark themselves more loudly.
+# Branch releases may be less restrictive
+# but also mark themselves more loudly.
 ##
 declare -r BRANCH_RELEASE
 
 ##
-# Utility function to echo to stderr.
+# Perform a release for the application, coordinating relevant bits.
 #
-# @param $@[in] The arguments to pass through to echo.
+# Release related actions will be performed by this script
+# so that it can manage some level of transactionaltiy and
+# rollback/abort as necessary.
+#
+# Currently this script is not particularly robust.
+# It should be strengthened as failure scenarios are encountered.
+#
+# Globals:
+#   prop_file[in]
+#   GIT[in]
+#   BIN_DIR[in]
+#   VERSION[in,out]
 ##
-release::error() {
-  echo "$@" >&2
-}
+release::main() {
+  release::find_deps
 
-##
-# Utility function to exit with a failure message.
-#
-# @param $1[in] - Message to output before exiting.
-##
-release::die() {
-  release::error "$1"
-  exit 1
+  local release_lock="${prop_file}.releasing"
+  release::validate_config "${release_lock}"
+  source ${prop_file}
+
+  [[ -n "${BRANCH_RELEASE}" ]] \
+    || release::git_is_synched \
+    || release::die 'Out of sync, aborting.'
+
+  touch "${release_lock}"
+
+  # Cut and push released version
+  release::update_version "Version to release" "$(release::determine_version)"
+
+  release::pre_release_hook || release::info 'No pre_release hooks'
+
+  ${GIT} add "${prop_file}"
+  ${GIT} commit -m "Update to version ${VERSION}"
+  ${GIT} tag -a "${VERSION}" -m "Release [${VERSION}]"
+  ${GIT} push origin ${VERSION}
+
+  [[ -n "${BRANCH_RELEASE}" ]] || release::postrelease_version
+
+  rm "${release_lock}"
 }
 
 ##
 # Locate and set dependencies or die trying.
 ##
 release::find_deps() {
-  if [[ -n "${GIT:=$(which git)}" ]]; then
+  if [[ -x "${GIT:=$(which git)}" ]]; then
     readonly GIT
   else
-    die "git is required but was not found!"
+    release::die "git is required but cannot be found or executed!"
   fi
-
   if [[ -z "${RELEASE_HOOK_DIR}" ]]; then
-    RELEASE_HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    RELEASE_HOOK_DIR="$( \
+      cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
     readonly RELEASE_HOOK_DIR
+  fi
+}
+
+##
+# Assert that the configuration and invocation are valid.
+#
+# If validation fails then the script will output an error
+# and exit with a failure status of 1.
+#
+# Globals:
+#   prop_file[in]
+#
+# @param $1 The file name of the an in-flight release lock.
+##
+release::validate_config() {
+  local release_lock=$1
+
+  [[ "${prop_file}" ]] || release::die \
+    'Missing Argument' "$(release::usage)"
+
+  [[ -f "${prop_file}" ]] || release::die \
+    "Build property file ${prop_file} not present or not a file."
+
+  [[ -w "${prop_file}" ]] || release::die \
+    "Build property file ${prop_file} is not writable."
+
+  # The test is flipped so the expression/return is successful.
+  [[ ! -f "${release_lock}" ]] || release::die \
+    "${release_lock} already exists." \
+    " Clean up previous release before continuing."
+}
+
+##
+# Check whether the current git branch is in-synch with its origin.
+#
+# This includes verifying that the current branch is master
+# and the revisions match between the peers.
+#
+# Globals:
+#   GIT
+#
+# @return 0 (success) if everything appears to be in sync,
+#         1 (failure) if there is a mismatch.
+##
+release::git_is_synched() {
+  local status
+  local statuses
+  local -i synched
+
+  # Make sure to have an up-to-date view of origin.
+  ${GIT} remote update
+
+  statuses=$(${GIT} status -sb | awk \
+    '/##/ { \
+      if ($2 != "master...origin/master") { print "NOT_MASTER" }; \
+      s[$3]=1 \
+    }; \
+    {s[$1]=1} \
+    END {for (t in s) { print t}}')
+  (( synched=0 ))
+
+  for status in $statuses; do
+    case $status in
+      'NOT_MASTER')
+        release::error 'Not on master!.'
+        (( synched=1 ))
+        ;;
+      'M')
+        release::error 'Modified files exist. Commit and push change.'
+        (( synched=1 ))
+        ;;
+      '[ahead')
+        release::error 'Local git is ahead of origin. Push changes.'
+        (( synched=1 ))
+        ;;
+      '[behind')
+        release::error 'Local git is behind origin. Pull changes.'
+        (( synched=1 ))
+        ;;
+    esac
+  done
+
+  return $synched
+}
+
+##
+# Output the version to release (to be captured).
+#
+# If RELEASE_VERSION is specified, echoes that value.
+#
+# Will use the release_version handler if registered,
+# otherwise will return VERSION without a '-QUALIFIER`.
+#
+# If such a handler is installed it will be passed
+# VERSION as an argument and should write the version
+# to release to stdout (and that should be the only output
+# of the handler).
+##
+release::determine_version() {
+#  release::handler_fn 'release_version' "${VERSION}" \
+#    || release::handler_scripts 'release_version' "${VERSION}" \
+  if [[ "${RELEASE_VERSION}" ]]; then
+    echo "${RELEASE_VERSION}"
+  else
+    echo "${VERSION%%-*}"
   fi
 }
 
@@ -118,9 +283,10 @@ release::find_deps() {
 # Globals:
 #   prop_file[in]
 #   VERSION[out]
+#   AUTO_VERSION[in]
 #
-# @param $1[in] The text prompt to display to the user.
-# @param $2[in] The default version to display and use if nothing is entered.
+# @param $1 The text prompt to display to the user.
+# @param $2 The default version to display and use if nothing is entered.
 ##
 release::update_version() {
   local prompt=$1
@@ -132,9 +298,15 @@ release::update_version() {
   temp_file="${prop_file}.release"
   [[ -f "${temp_file}" ]] && release::die "${temp_file} file already exists. Remove if stale"
 
+
   # Determine new version.
   [[ "${BRANCH_RELEASE}" ]] && prompt="(BRANCH) $prompt"
-  read -p "${prompt} [${default_version}]:" version_provided
+  if [[ "${AUTO_VERSION}" ]]; then
+    release::info "Releasing version: '${default_version}'"
+  else
+    read -p "${prompt} [${default_version}]:" version_provided
+  fi
+
   new_version=${version_provided:-$default_version}
   [[ "${BRANCH_RELEASE}" ]] && new_version="${new_version}-BRANCH"
 
@@ -142,6 +314,67 @@ release::update_version() {
   sed "s/^VERSION=.*$/VERSION=${new_version}/" "${prop_file}" > "${temp_file}"
   mv "${temp_file}" "${prop_file}"
   source "${prop_file}"
+}
+
+##
+# Call all pre_release_hook scripts or functions.
+#
+# Any script present in the RELEASE_HOOK_DIR and any defined functions
+# matching the pattern
+# 'pre_release_' will be executed as:
+#    $script "${prop_file}" "${VERSION}" "${BRANCH_RELEASE}"
+##
+release::pre_release_hook() {
+  release::handler_scripts 'pre_release_*' "${prop_file}" "${VERSION}" "${BRANCH_RELEASE}"
+  release::handler_fns 'pre_release_' "${prop_file}" "${VERSION}" "${BRANCH_RELEASE}"
+}
+
+##
+# Optionally output information about typical operation.
+#
+# This will be suppressed if not in verbose mode.
+#
+# @param $@ Informative message.
+##
+release::info() {
+  [[ -z "$RELEASE_VERBOSE" ]] || echo $@
+}
+
+##
+# Utility function to exit with a failure message.
+#
+# @param $@ Message to output before exiting.
+##
+release::die() {
+  release::error "ERROR: $@"
+  exit 1
+}
+
+##
+# Output usage information.
+#
+# Will output guidance on how to invoke this script
+# for cases where it has not been invoked usably.
+##
+release::usage() {
+  cat <<EOF
+
+Usage: $me <prop_file>
+
+prop_file
+	The name of the properties file containing the VERSION.
+
+More documentation is available in the script file itself.
+EOF
+}
+
+##
+# Utility function to echo to stderr.
+#
+# @param $@ The arguments to pass through to echo.
+##
+release::error() {
+  echo "$@" >&2
 }
 
 ##
@@ -159,125 +392,65 @@ release::update_version() {
 release::postrelease_version() {
   local -i new_micro
   let new_micro="${VERSION##*.}"+1
+
   release::update_version "Post-release version" "${VERSION%.*}.${new_micro}-SNAPSHOT"
+
   ${GIT} add "${prop_file}"
   ${GIT} commit -m "Post release version ${VERSION}"
   ${GIT} push
 }
 
 ##
-# Check whether the current git branch seems to be in-synch with its origin.
+# Execute any present handler functions baed on the provided arguments.
 #
-# This includes verifying that the current branch is master and the revisions
-# match between the peers.
+# The first paramter s the pattern or name of functions to invoke,
+# and all further parameters will be passed to the function.
 #
-# Globals:
-#   GIT
-#
-# @return 0 (success) if everything appears to be in sync,
-#         1 (failure) if there is a mismatch.
+# @param $1 Specify the name or pattern of the handler function to invoke.
+# @param $2 Provide arguments to pass to the invoked functions.
+# @return 0 Return 0 if any functions were invoked, 1 if none were found.
 ##
-release::git_is_synched() {
-  local status
-  local statuses
-  local -i synched
-
-  statuses=$(${GIT} status -sb | awk '/##/ {if ($2 != "master...origin/master") { print "NOT_MASTER" }; s[$3]=1}; {s[$1]=1} END {for (t in s) { print t}}')
-  let synched=0
-
-  for status in $statuses; do
-    case $status in
-      'NOT_MASTER')
-        release::error 'Not on master!.'
-        let synched=1
-        ;;
-      'M')
-        release::error 'Modified files exist. Commit and push change.'
-        let synched=1
-        ;;
-      '[ahead')
-        release::error 'Local git is ahead of origin. Push changes.'
-        let synched=1
-        ;;
-      '[behind')
-        release::error 'Local git is behind origin. Pull changes.'
-        let synched=1
-        ;;
-    esac
+release::handler_fns() {
+  local fn
+  local -i unfound=1
+  args="${@:2}"
+  for fn in $(compgen -A function "$1"); do
+    ${fn} ${args}
+    unfound=0
   done
-
-  return $synched
+  [[ $unfound -eq 0 ]]
 }
 
 ##
-# Call all pre_release_hook scripts.
+# Execute any present handler scripts based on the provided arguments.
 #
-# Any script present in the RELEASE_HOOK_DIR matching the pattern
-# 'pre_release_' will be executed as:
-#    $script "${prop_file}" "${VERSION}" "${BRANCH_RELEASE}"
+# The first parameter is the pattern or name of scripts to invoke,
+# and all further parameters will be passed to the script.
+# If any handler script exists but fails, execution will abort
+# with that failure.
+#
+# @param $1 Specify the name or pattern of the handler scripts to execute.
+# @param $2 Provide arguments to pass to the invoked scripts.
+# @return Return 0 if any scripts were found, 1 if none were found.
 ##
-release::pre_release_hook() {
-  local script;
-  shopt -s nullglob;
-  for script in ${RELEASE_HOOK_DIR}/pre_release_*; do
-    if [[ -x "$script" ]]; then
-      "$script" "${prop_file}" "${VERSION}" "${BRANCH_RELEASE}" || exit $?
+release::handler_scripts() {
+  local script
+  local -i unfound=1
+  shopt -s nullglob
+  args="${@:2}"
+  for script in "${RELEASE_HOOK_DIR}"/$1; do
+    if [[ -x "${script}" ]]; then
+      ${script} ${args} || exit $?
+      unfound=0
     else
       release::error "$script is not executable, skipping."
     fi
   done
   shopt -u nullglob;
+  [[ $unfound -eq 0 ]]
 }
 
-##
-# Perform a release for the application, coordinating relevant bits.
-#
-# Eveything release related will be done in this script so it's easier to
-# treat the actions as atomic and rollback/abort as necessary.
-#
-# Currently this script is not particularly robust. It should be strengthened as failure
-# scenarios are encountered.
-#
-# Globals:
-#    prop_file[in]
-#    GIT[in]
-#    BIN_DIR[in]
-#    VERSION[in,out]
-##
-release::main() {
-  local release_lock
 
-  [[ -f "${prop_file}" ]] || release::die "Build property file ${prop_file} not present".
-
-  release_lock="${prop_file}.releasing"
-  [[ -f "${release_lock}" ]] && release::die "${release_lock} already exists. Clean up previous release before continuing"
-
-  # Check to make sure git is fully synched.
-  ${GIT} remote update
-
-  [[ -n "${BRANCH_RELEASE}" ]] \
-    || release::git_is_synched \
-    || release::die 'Out of sync, aborting.'
-
-  touch "${release_lock}"
-
-  # Cut and push released version
-  release::update_version "Version to release" "${VERSION%%-*}"
-
-  release::pre_release_hook
-
-  ${GIT} add "${prop_file}"
-  ${GIT} commit -m "Update to version ${VERSION}"
-  ${GIT} tag -a "${VERSION}" -m "Release [${VERSION}]"
-  ${GIT} push origin ${VERSION}
-
-  [[ -n "${BRANCH_RELEASE}" ]] || release::postrelease_version
-
-  rm "${release_lock}"
-}
-
-release::find_deps
-source ${prop_file}
 release::main
 
 exit 0

--- a/test/release/created_release.bats
+++ b/test/release/created_release.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'Create a git tag for the release.' {
+  in_test_dir 'tag_created'
+  echo 'VERSION=1.4-SNAPSHOT' > build.properties
+  init_with_origin 'tag_created_origin'
+  AUTO_VERSION=true run ./release build.properties
+  [[ "$(git tag -l '1.4')" == '1.4' ]]
+}
+
+@test 'Include the version build.properties in the release tag.' {
+  in_test_dir 'tag_props'
+  echo 'VERSION=1.6-SNAPSHOT' > build.properties
+  init_with_origin 'tag_props_origin'
+  AUTO_VERSION=true run ./release build.properties
+  git checkout '1.6'
+  [[ "$(<build.properties)" = 'VERSION=1.6' ]]
+}
+

--- a/test/release/post_release.bats
+++ b/test/release/post_release.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'When done releasing, increment last doublet version number in build.properties.' {
+  in_test_dir 'version_bump'
+  echo 'VERSION=1.0-SNAPSHOT' > build.properties
+  init_with_origin 'version_bump_origin'
+  AUTO_VERSION=true run ./release build.properties
+  [[ "$(<build.properties)" == 'VERSION=1.1-SNAPSHOT' ]]
+}
+
+@test 'When done releasing, increment last triplet version number in build.properties.' {
+  in_test_dir 'version_bump'
+  echo 'VERSION=1.2.9-SNAPSHOT' > build.properties
+  init_with_origin 'version_bump_origin'
+  AUTO_VERSION=true run ./release build.properties
+  [[ "$(<build.properties)" == 'VERSION=1.2.10-SNAPSHOT' ]]
+}
+
+@test 'When done releasing, git is synched.' {
+  in_test_dir 'post_synched'
+  echo 'VERSION=1.0-SNAPSHOT' > build.properties
+  init_with_origin 'post_synched_origin'
+  AUTO_VERSION=true run ./release build.properties
+  [[ -z "$(git status -s)" ]]
+}
+
+@test 'Reflect the release in the git log.' {
+  in_test_dir 'logs'
+  echo 'VERSION=2.3.2-SNAPSHOT' > build.properties
+  init_with_origin 'logs_origin'
+  AUTO_VERSION=true run ./release build.properties
+  mapfile -t logs < <(git log HEAD~2..HEAD --oneline --no-decorate | cut -d ' ' -f2-)
+  [[ "${logs[0]}" == 'Post release version 2.3.3-SNAPSHOT' ]]
+  [[ "${logs[1]}" == 'Update to version 2.3.2' ]]
+}

--- a/test/release/pre_release.bats
+++ b/test/release/pre_release.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'When a pre_release script exists, invoke with expected args.' {
+  setup_valid_dir 'pre_release_script'
+  echo 'echo "Hooked $@"' > pre_release_echo
+  chmod +x pre_release_echo
+  sync_with_origin
+  AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Hooked\ build\.properties\ 1\.0 ]]
+}
+
+@test 'When a pre_release function exists, invoke with expected args.' {
+  setup_valid_dir 'pre_release_fn'
+
+  pre_release_test() { echo "Function called with: $@"; }
+  export -f pre_release_test
+
+  AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Function\ called\ with:\ build\.properties\ 1\.0 ]]
+}
+
+@test 'When multiple pre_release functions exist, invoke each with expected args.' {
+  setup_valid_dir 'pre_release_fn'
+
+  pre_release_test() { echo "Function called with: $@"; }
+  pre_release_2() { echo "Second called with: $@"; }
+  export -f pre_release_test pre_release_2
+
+  AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Function\ called\ with:\ build\.properties\ 1\.0 ]]
+  [[ "${output}" =~ Second\ called\ with:\ build\.properties\ 1\.0 ]]
+}
+
+@test 'When a pre_release script and function exist, invoke both types.' {
+  setup_valid_dir 'pre_release_script'
+  echo 'echo "Hooked $@"' > pre_release_echo
+  chmod +x pre_release_echo
+  sync_with_origin
+
+  pre_release_test() { echo "Function called with: $@"; }
+  export -f pre_release_test
+
+  AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Hooked\ build\.properties\ 1\.0 ]]
+  [[ "${output}" =~ Function\ called\ with:\ build\.properties\ 1\.0 ]]
+}
+
+@test 'When multiple pre_release scripts exist, invoke each.' {
+  setup_valid_dir 'pre_release_script'
+  echo 'echo "Hooked $@"' > pre_release_echo
+  echo 'echo "Another"' > pre_release_another
+  chmod +x pre_release_echo
+  chmod +x pre_release_another
+  sync_with_origin
+  AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Hooked\ build\.properties\ 1\.0 ]]
+  [[ "${output}" =~ Another ]]
+}
+
+@test 'When a pre_release scripts is not executable, do not invoke.' {
+  setup_valid_dir 'pre_release_script'
+  echo 'echo "Hooked $@"' > pre_release_echo
+  sync_with_origin
+  AUTO_VERSION=true run ./release build.properties
+  [[ ! "${output}" =~ Hooked\ build\.properties\ 1\.0 ]]
+}
+

--- a/test/release/preconditions.bats
+++ b/test/release/preconditions.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'When git is not found, return failure status.' {
+  in_test_dir 'bad_config'
+  export GIT=./git
+  run ./release
+  (( "${status}" == 1 ))
+}
+
+@test 'When git is not found, output a fitting message.' {
+  in_test_dir 'bad_config'
+  export GIT=./git
+  run ./release
+  [[ "${output}" =~ ERROR.*git ]]
+}
+
+@test 'When argument is omitted, return failure status.' {
+  in_test_dir 'bad_config'
+  run ./release
+  (( "${status}" == 1 ))
+}
+
+@test 'When argument is omitted, output usage info.' {
+  in_test_dir 'bad_config'
+  run ./release
+  [[ "${output}" == *Usage* ]]
+}
+
+@test 'When properties is missing, return failure status.' {
+  in_test_dir 'bad_config'
+  run ./release missing.properties
+  (( "${status}" == 1 ))
+}
+
+@test 'When properties is missing, output a fitting message.' {
+  in_test_dir 'bad_config'
+  run ./release missing.properties
+  [[ "${output}" =~ ERROR.*not\ present ]]
+}
+
+@test 'When properties is not a regular file, return failure status.' {
+  in_test_dir 'bad_config'
+  mkdir dir1.properties
+  run ./release dir1.properties
+  (( "${status}" == 1 ))
+}
+
+@test 'When properties is not a regular file, output a fitting message.' {
+  in_test_dir 'bad_config'
+  mkdir dir2.properties
+  run ./release dir2.properties
+  [[ "${output}" =~ ERROR.*not\ a\ file ]]
+}
+
+@test 'When properties is not writable, return failure status.' {
+  in_test_dir 'bad_config'
+  touch unwritable.properties && chmod -w unwritable.properties
+  run ./release unwritable.properties
+  (( "${status}" == 1 ))
+}
+
+@test 'When properties is not writable, output a fitting message.' {
+  in_test_dir 'bad_config'
+  touch unwritable.properties && chmod -w unwritable.properties
+  run ./release unwritable.properties
+  [[ "${output}" =~ ERROR.*writable ]]
+}
+
+@test 'When lock file already exists, return failure status.' {
+  in_test_dir 'bad_config'
+  touch locked.properties && touch locked.properties.releasing
+  run ./release locked.properties
+  (( "${status}" == 1 ))
+}
+
+@test 'When lock file already exists, output a fitting message.' {
+  in_test_dir 'bad_config'
+  touch locked.properties && touch locked.properties.releasing
+  run ./release locked.properties
+  [[ "${output}" =~ ERROR.*already ]]
+}
+
+@test 'When outside of a git repository, return failure status.' {
+  in_test_dir 'bad_config'
+  touch build.properties
+  run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'When outside of a git repository, output a fitting message.' {
+  in_test_dir 'bad_config'
+  touch build.properties
+  run ./release build.properties
+  [[ "${output}" =~ git\ repository ]]
+}

--- a/test/release/release_version.bats
+++ b/test/release/release_version.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'When no version is in file, use blank.' {
+  in_test_dir 'missing_version'
+  touch build.properties
+  init_with_origin 'missing_version_origin'
+  RELEASE_VERBOSE=true AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'\' ]]
+}
+
+@test 'When blank version is in file, use blank.' {
+  in_test_dir 'blank_version'
+  echo 'VERSION=' > build.properties
+  init_with_origin 'blank_version_origin'
+  RELEASE_VERBOSE=true AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'\' ]]
+}
+
+@test 'When non-qualified version is in file, use as is.' {
+  in_test_dir 'release_version'
+  echo 'VERSION=1.0' > build.properties
+  init_with_origin 'release_version_origin'
+  RELEASE_VERBOSE=true AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'1\.0\' ]]
+}
+
+@test 'When qualified version is in file, remove that qualifier.' {
+  in_test_dir 'qual_version'
+  echo 'VERSION=1.0-SNAPSHOT' > build.properties
+  init_with_origin 'qual_version_origin'
+  RELEASE_VERBOSE=true AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'1\.0\' ]]
+}
+
+@test 'When over-qualified version is in file, remove all qualifiers.' {
+  in_test_dir 'qual_version'
+  echo 'VERSION=1.0-SNAPSHOT-build1' > build.properties
+  init_with_origin 'qual_version_origin'
+  RELEASE_VERBOSE=true AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'1\.0\' ]]
+}
+
+@test 'When no version is in file, use environment value if present.' {
+  in_test_dir 'missing_env_version'
+  touch build.properties
+  init_with_origin 'missing_env_version_origin'
+  RELEASE_VERBOSE=true VERSION=0.4 AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'0\.4\' ]]
+}
+
+@test 'When blank version is in file, ignore environment value.' {
+  in_test_dir 'blank_env_version'
+  echo 'VERSION=' > build.properties
+  init_with_origin 'blank_env_version_origin'
+  RELEASE_VERBOSE=true VERSION=0.4 AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'\' ]]
+}
+
+@test 'When RELEASE_VERSION is specified override value in the file.' {
+  in_test_dir 'overridden_version'
+  echo 'VERSION=1.0' > build.properties
+  init_with_origin 'overridden_version_origin'
+  RELEASE_VERBOSE=true RELEASE_VERSION=2.0 AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ Releasing\ version:\ \'2\.0\' ]]
+}
+
+@test 'When build.properties.release already exists, return error status.' {
+  in_test_dir 'stale_release'
+  echo 'VERSION=1.0' > build.properties
+  touch build.properties.release
+  init_with_origin 'stale_release_origin'
+  AUTO_VERSION=true run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'When build.properties.release already exists, output fitting message.' {
+  in_test_dir 'stale_release'
+  echo 'VERSION=1.0' > build.properties
+  touch build.properties.release
+  init_with_origin 'stale_release_origin'
+  AUTO_VERSION=true run ./release build.properties
+  [[ "${output}" =~ file\ already\ exists. ]]
+}

--- a/test/release/releasing.bats
+++ b/test/release/releasing.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'When everything is in order, return success.' {
+  in_test_dir 'tag_version'
+  echo 'VERSION=1.0-SNAPSHOT' > build.properties
+  init_with_origin 'tag_version_origin'
+  AUTO_VERSION=true run ./release build.properties
+  git checkout '1.0'
+  (( "${status}" == 0 ))
+}
+
+@test 'When releasing, tag build.properties with released version.' {
+  in_test_dir 'tag_version'
+  echo 'VERSION=1.0-SNAPSHOT' > build.properties
+  init_with_origin 'tag_version_origin'
+  AUTO_VERSION=true run ./release build.properties
+  git checkout '1.0'
+  [[ "$(<build.properties)" == 'VERSION=1.0' ]]
+}
+
+@test 'When done releasing, remove lock file.' {
+  in_test_dir 'tag_version'
+  echo 'VERSION=1.0-SNAPSHOT' > build.properties
+  init_with_origin 'tag_version_origin'
+  AUTO_VERSION=true run ./release build.properties
+  [[ ! -f build.properties.releasing ]]
+}
+

--- a/test/release/test_helper.bash
+++ b/test/release/test_helper.bash
@@ -1,0 +1,34 @@
+readonly release_src="${BATS_TEST_DIRNAME}/../../release"
+
+MY_TMPDIR="${BATS_TMPDIR}/$$"
+MY_VERSION='1.0'
+
+in_test_dir() {
+  local work_dir="${MY_TMPDIR}/$1"
+  mkdir -p "${work_dir}"
+  cp "${release_src}" "${work_dir}"
+  cd "${work_dir}"
+}
+
+init_with_origin() {
+  local origin_dir="${MY_TMPDIR}/$1"
+  mkdir -p "${origin_dir}"
+  git init --bare "${origin_dir}"
+  git init .
+  git remote add origin "file://${origin_dir}"
+  git add .
+  git commit -m 'Sync to origin'
+  git push --set-upstream origin master
+}
+
+setup_valid_dir() {
+  in_test_dir "$1"
+  echo "VERSION=${MY_VERSION}-SNAPSHOT" > build.properties
+  init_with_origin "$1_origin"
+}
+
+sync_with_origin() {
+  git add .
+  git commit -m 'Sync to origin'
+  git push
+}

--- a/test/release/unsynched.bats
+++ b/test/release/unsynched.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test 'When untracked files exist, return failure status.' {
+  in_test_dir 'untracked'
+  init_with_origin 'untracked_origin'
+  touch build.properties
+  run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'When untracked files exist, output a fitting message.' {
+  in_test_dir 'untracked'
+  init_with_origin 'untracked_origin'
+  touch build.properties
+  run ./release build.properties
+  [[ "${output}" =~ Modified ]]
+  [[ "${output}" =~ Out\ of\ sync ]]
+}
+
+@test 'When not on master, return failure status.' {
+  in_test_dir 'nonmaster'
+  touch build.properties
+  init_with_origin 'nonmaster_origin'
+  git checkout -B other
+  run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'When not on master, output a fitting message.' {
+  in_test_dir 'nonmaster'
+  touch build.properties
+  init_with_origin 'nonmaster_origin'
+  git checkout -B other
+  run ./release build.properties
+  [[ "${output}" =~ Not\ on\ master ]]
+  [[ "${output}" =~ Out\ of\ sync ]]
+}
+
+@test 'With unstaged modifications, return failure status.' {
+  in_test_dir 'unstaged'
+  touch build.properties
+  init_with_origin 'unstaged_origin'
+  run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'With unstaged modifications, output a fitting message.' {
+  in_test_dir 'unstaged'
+  touch build.properties
+  init_with_origin 'unstaged_origin'
+  run ./release build.properties
+  [[ "${output}" =~ Modified ]]
+  [[ "${output}" =~ Out\ of\ sync ]]
+}
+
+@test 'When ahead of master, return failure status.' {
+  in_test_dir 'ahead'
+  touch build.properties
+  init_with_origin 'ahead_origin'
+  touch new_file
+  git add .
+  git commit -m "Added new_file"
+  run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'When ahead of master, output a fitting message.' {
+  in_test_dir 'ahead'
+  touch build.properties
+  init_with_origin 'ahead_origin'
+  touch new_file
+  git add .
+  git commit -m "Added new_file"
+  run ./release build.properties
+  [[ "${output}" =~ ahead\ of\ origin ]]
+  [[ "${output}" =~ Out\ of\ sync ]]
+}
+
+@test 'When behind master, return failure status.' {
+  in_test_dir 'behind'
+  touch build.properties
+  init_with_origin 'behind_origin'
+  touch new_file
+  git add .
+  git commit -m "Added new_file"
+  git push
+  git reset --hard HEAD^
+  run ./release build.properties
+  (( "${status}" != 0 ))
+}
+
+@test 'When behind master, output a fitting message.' {
+  in_test_dir 'behind'
+  touch build.properties
+  init_with_origin 'behind_origin'
+  touch new_file
+  git add .
+  git commit -m "Added new_file"
+  git push
+  git reset --hard HEAD^
+  run ./release build.properties
+  [[ "${output}" =~ behind\ origin ]]
+  [[ "${output}" =~ Out\ of\ sync ]]
+}
+


### PR DESCRIPTION
This includes some loose ends that should be tied up in subsequent PRs: this one focuses on specifying the current behavior while the purpose is to support some of the extensions which can now be added (such as a pluggable versioning strategy)